### PR TITLE
Proper error on Submariner not installed

### DIFF
--- a/pkg/subctl/cmd/show.go
+++ b/pkg/subctl/cmd/show.go
@@ -20,9 +20,15 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
+	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 )
 
 // showCmd represents the show command
@@ -97,4 +103,21 @@ func getClientConfigAndClusterName(rules *clientcmd.ClientConfigLoadingRules, ov
 	}
 
 	return restConfig{config: clientConfig, clusterName: *clusterName}, nil
+}
+
+func GetSubmarinerResource(config *rest.Config) *v1alpha1.Submariner {
+	submarinerClient, err := submarinerclientset.NewForConfig(config)
+	exitOnError("Unable to get the Submariner client", err)
+
+	submariner, err := submarinerClient.SubmarinerV1alpha1().Submariners(OperatorNamespace).Get(submarinercr.SubmarinerName, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Println("Submariner is not installed")
+			return nil
+		}
+
+		exitOnError("Error obtaining the Submariner resource", err)
+	}
+
+	return submariner
 }

--- a/pkg/subctl/cmd/show_all.go
+++ b/pkg/subctl/cmd/show_all.go
@@ -26,14 +26,23 @@ func showAll(cmd *cobra.Command, args []string) {
 		fmt.Println()
 		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
 
+		fmt.Println("Showing Network details")
 		showNetworkSingleCluster(item.config)
-		fmt.Println()
-		showEndpointsFromConfig(item.config)
-		fmt.Println()
-		showConnectionsFromConfig(item.config)
-		fmt.Println()
-		showGatewaysFromConfig(item.config)
-		fmt.Println()
-		showVersionsFromConfig(item.config)
+		fmt.Println("")
+
+		submariner := GetSubmarinerResource(item.config)
+
+		if submariner == nil {
+			continue
+		}
+
+		fmt.Println("\nShowing Endpoint details")
+		showEndpointsFor(submariner)
+		fmt.Println("\nShowing Connection details")
+		showConnectionsFor(submariner)
+		fmt.Println("\nShowing Gateway details")
+		showGatewaysFor(submariner)
+		fmt.Println("\nShowing version details")
+		getVersionsFor(item.config)
 	}
 }

--- a/pkg/subctl/cmd/show_gateways.go
+++ b/pkg/subctl/cmd/show_gateways.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/operator/submarinercr"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
+
+	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
 )
 
 type gatewayStatus struct {
@@ -28,17 +26,10 @@ func init() {
 	showCmd.AddCommand(showGatewaysCmd)
 }
 
-func getGatewaysStatus(config *rest.Config) []gatewayStatus {
-	submarinerClient, err := submarinerclientset.NewForConfig(config)
-	exitOnError("Unable to get the Submariner client", err)
-
+func getGatewaysStatus(submariner *v1alpha1.Submariner) []gatewayStatus {
 	var status []gatewayStatus
-	existingCfg, err := submarinerClient.SubmarinerV1alpha1().Submariners(OperatorNamespace).Get(submarinercr.SubmarinerName, v1.GetOptions{})
-	if err != nil {
-		exitOnError("error reading from submariner client", err)
-	}
 
-	gateways := existingCfg.Status.Gateways
+	gateways := submariner.Status.Gateways
 	if gateways == nil {
 		exitWithErrorMsg("no gateways found")
 	}
@@ -82,14 +73,15 @@ func showGateways(cmd *cobra.Command, args []string) {
 	for _, item := range configs {
 		fmt.Println()
 		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
-		status := getGatewaysStatus(item.config)
-		printGateways(status)
+		showGatewaysFor(GetSubmarinerResource(item.config))
 	}
 }
 
-func showGatewaysFromConfig(config *rest.Config) {
-	status := getGatewaysStatus(config)
-	printGateways(status)
+func showGatewaysFor(submariner *v1alpha1.Submariner) {
+	if submariner != nil {
+		status := getGatewaysStatus(submariner)
+		printGateways(status)
+	}
 }
 
 func printGateways(gateways []gatewayStatus) {

--- a/pkg/subctl/cmd/show_versions.go
+++ b/pkg/subctl/cmd/show_versions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/submariner-operator/apis/submariner/v1alpha1"
 	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
@@ -40,14 +41,9 @@ func newVersionInfoFrom(repository, component, version string) versionImageInfo 
 	}
 }
 
-func getSubmarinerVersion(submarinerClient submarinerclientset.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
-	existingCfg, err := submarinerClient.SubmarinerV1alpha1().Submariners(OperatorNamespace).Get(submarinercr.SubmarinerName, v1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	versions = append(versions, newVersionInfoFrom(existingCfg.Spec.Repository, submarinercr.SubmarinerName, existingCfg.Spec.Version))
-	return versions, nil
+func getSubmarinerVersion(submariner *v1alpha1.Submariner, versions []versionImageInfo) []versionImageInfo {
+	versions = append(versions, newVersionInfoFrom(submariner.Spec.Repository, submarinercr.SubmarinerName, submariner.Spec.Version))
+	return versions
 }
 
 func getOperatorVersion(clientSet kubernetes.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
@@ -78,7 +74,7 @@ func getServiceDiscoveryVersions(submarinerClient submarinerclientset.Interface,
 	return versions, nil
 }
 
-func getVersions(config *rest.Config) []versionImageInfo {
+func getVersions(config *rest.Config, submariner *v1alpha1.Submariner) []versionImageInfo {
 	var versions []versionImageInfo
 
 	submarinerClient, err := submarinerclientset.NewForConfig(config)
@@ -87,7 +83,7 @@ func getVersions(config *rest.Config) []versionImageInfo {
 	clientSet, err := kubernetes.NewForConfig(config)
 	exitOnError("Unable to get the Operator config", err)
 
-	versions, err = getSubmarinerVersion(submarinerClient, versions)
+	versions = getSubmarinerVersion(submariner, versions)
 	exitOnError("Unable to get the Submariner versions", err)
 
 	versions, err = getOperatorVersion(clientSet, versions)
@@ -99,20 +95,22 @@ func getVersions(config *rest.Config) []versionImageInfo {
 	return versions
 }
 
+func getVersionsFor(config *rest.Config) {
+	submariner := GetSubmarinerResource(config)
+	if submariner != nil {
+		versions := getVersions(config, submariner)
+		printVersions(versions)
+	}
+}
+
 func showVersions(cmd *cobra.Command, args []string) {
 	configs, err := getMultipleRestConfigs(kubeConfig, kubeContext)
 	exitOnError("Error getting REST config for cluster", err)
 	for _, item := range configs {
 		fmt.Println()
 		fmt.Printf("Showing information for cluster %q:\n", item.clusterName)
-		versions := getVersions(item.config)
-		printVersions(versions)
+		getVersionsFor(item.config)
 	}
-}
-
-func showVersionsFromConfig(config *rest.Config) {
-	versions := getVersions(config)
-	printVersions(versions)
 }
 
 func printVersions(versions []versionImageInfo) {


### PR DESCRIPTION
This patch does the follwong:
1. Print proper error message while running
   subctl show * when submariner is not
   installed/removed in/from the cluster
2. Don't exit when subctl show * fails on
   a cluster rather enumerate other clusters

Closes: #957
Closes: #958

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>